### PR TITLE
update to 1.28.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,7 +1,0 @@
-upload_without_merge: true
-upload_channels:
-  - marekw
-channels:
-  - marekw
-build_parameters:
-  - ""

--- a/abs.yaml
+++ b/abs.yaml
@@ -3,3 +3,5 @@ upload_channels:
   - marekw
 channels:
   - marekw
+build_parameters:
+  - ""

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+upload_without_merge: true
+upload_channels:
+  - marekw
+channels:
+  - marekw

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,8 @@ requirements:
     - woodwork >=0.23.0
 test:
   commands:
-    - pip check
+    # docker-py has an exact pinning for pywin32 that cause pip check to fail.
+    - pip check  # [not win]
     #test_nans fails with Intel MKL, so openblas is used
     - pytest --pyargs featuretools -v -k "not test_nans"  # [win]
     - pytest --pyargs featuretools -v  # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,12 +30,27 @@ requirements:
     - tqdm >=4.32.0
     - woodwork >=0.23.0
 test:
+  source_files:
+    - featuretools/tests
   commands:
     - pip check
+    - pytest -k "not (test_get_featuretools_root or test_nans)"
   imports:
     - featuretools
   requires:
     - pip
+    - boto3 >=1.17.46
+    - composeml >=0.8.0
+    - graphviz >=0.8.4
+    - moto >=3.0.7
+    - pyarrow >=3.0.0,<13.0.0
+    - pympler >=0.8
+    - pytest >=7.1.2
+    - pytest-timeout >=2.1.0
+    - pytest-xdist >=2.5.0
+    - python-graphviz >=0.8.4
+    - smart_open >=5.0.0
+    - urllib3 >=1.26.5
 
 about:
   doc_url: https://featuretools.alteryx.com

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,14 +9,15 @@ source:
   sha256: 33612eb1528a55ce4700f0c420c7775f4ff0533d5f256251ad6c07a17787f774
 
 build:
-  noarch: python
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install --no-deps --no-build-isolation -vv .
 
 requirements:
   host:
     - pip
-    - python >=3.8.*
+    - python
+    - wheel
+    
   run:
     - cloudpickle >=1.5.0
     - holidays >=0.13, <0.33.0
@@ -24,40 +25,22 @@ requirements:
     - packaging >=20.0
     - pandas >=1.5.0
     - psutil >=5.6.6
-    - python >=3.8.*
+    - python
     - scipy >=1.10.0
     - tqdm >=4.32.0
     - woodwork >=0.23.0
 test:
   commands:
-    - pytest -n 2 --pyargs featuretools
+    - pip check
   imports:
     - featuretools
   requires:
-    - boto3 >=1.17.46
-    - composeml >=0.8.0
-    - graphviz !=2.47.2
-    - moto >=3.0.7
-    - pip >=21.3.1
-    - pyarrow >=3.0.0, <13.0.0
-    - pympler >=0.8
-    - pytest >=7.1.2
-    - pytest-cov >=3.0.0
-    - pytest-timeout >=2.1.0
-    - pytest-xdist >=2.5.0
-    - python-graphviz >=0.8.4
-    - smart_open >=5.0.0
-    - urllib3 >=1.26.5
-  source_files:
-    - featuretools/*
-    - pyproject.toml
-    - LICENSE
-    - README.md
+    - pip
 
 about:
   doc_url: https://featuretools.alteryx.com
   dev_url: https://github.com/alteryx/Featuretools
-  home: https://www.featuretools.com
+  home: https://featuretools.com/
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,6 @@ source:
 
 build:
   number: 0
-  #trigger 1
   script: {{ PYTHON }} -m pip install --no-deps --no-build-isolation -vv .
 
 requirements:
@@ -35,7 +34,8 @@ test:
     - featuretools/tests
   commands:
     - pip check
-    - pytest -k "not (test_get_featuretools_root or test_nans)"
+    - pytest -k "not (test_get_featuretools_root or test_nans)" # [win]
+    - pytest -k "not test_get_featuretools_root"  #  [not win]
   imports:
     - featuretools
   requires:
@@ -52,6 +52,7 @@ test:
     - python-graphviz >=0.8.4
     - smart_open >=5.0.0
     - urllib3 >=1.26.5
+    - openblas  #  [not win]
 
 about:
   doc_url: https://featuretools.alteryx.com

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 33612eb1528a55ce4700f0c420c7775f4ff0533d5f256251ad6c07a17787f774
 
 build:
-  skip: true  # [s390x]
+  skip: true  # [py<38 or s390x]
   number: 0
   script: {{ PYTHON }} -m pip install --no-deps --no-build-isolation -vv .
 
@@ -18,10 +18,11 @@ requirements:
     - pip
     - python
     - wheel
+    - setuptools
     
   run:
     - cloudpickle >=1.5.0
-    - holidays >=0.13, <0.33.0
+    - holidays >=0.13,<0.33.0
     - numpy >=1.21.0
     - packaging >=20.0
     - pandas >=1.5.0
@@ -31,12 +32,11 @@ requirements:
     - tqdm >=4.32.0
     - woodwork >=0.23.0
 test:
-  source_files:
-    - featuretools/tests
   commands:
     - pip check
-    - pytest -k "not (test_get_featuretools_root or test_nans)"  # [win]
-    - pytest -k "not test_get_featuretools_root"  # [not win]
+    #test_nans fails with Intel MKL, so openblas is used
+    - pytest --pyargs featuretools -v -k "not test_nans"  # [win]
+    - pytest --pyargs featuretools -v  # [not win]
   imports:
     - featuretools
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,7 @@ source:
 
 build:
   number: 0
+  #trigger 1
   script: {{ PYTHON }} -m pip install --no-deps --no-build-isolation -vv .
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,6 +9,7 @@ source:
   sha256: 33612eb1528a55ce4700f0c420c7775f4ff0533d5f256251ad6c07a17787f774
 
 build:
+  skip: true  # [s390x]
   number: 0
   script: {{ PYTHON }} -m pip install --no-deps --no-build-isolation -vv .
 
@@ -34,8 +35,8 @@ test:
     - featuretools/tests
   commands:
     - pip check
-    - pytest -k "not (test_get_featuretools_root or test_nans)" # [win]
-    - pytest -k "not test_get_featuretools_root"  #  [not win]
+    - pytest -k "not (test_get_featuretools_root or test_nans)"  # [win]
+    - pytest -k "not test_get_featuretools_root"  # [not win]
   imports:
     - featuretools
   requires:
@@ -52,7 +53,7 @@ test:
     - python-graphviz >=0.8.4
     - smart_open >=5.0.0
     - urllib3 >=1.26.5
-    - openblas  #  [not win]
+    - openblas  # [not win]
 
 about:
   doc_url: https://featuretools.alteryx.com


### PR DESCRIPTION
request from snowflake, was supposed to go to snowflake channel, but actually it is update on existing package on default channel

- [upstream](https://github.com/alteryx/featuretools)
- removed tests as there is cyclic dependency on composeml in tests, will get back to it once composeml is done
- add private channel as there are cyclic dependencies between feedstocks in tests
- add openblast to test requirements so test_nans test passes

